### PR TITLE
#155820624 Launch detail activity from main activity

### DIFF
--- a/app/src/main/java/com/example/githubusers/DetailActivity.java
+++ b/app/src/main/java/com/example/githubusers/DetailActivity.java
@@ -1,7 +1,9 @@
 package com.example.githubusers;
 
+import android.content.Intent;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
+import android.widget.TextView;
 
 public class DetailActivity extends AppCompatActivity {
 
@@ -9,5 +11,25 @@ public class DetailActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_detail);
+
+        //Get the caller intent
+        Intent intent = getIntent();
+        String extra_username = intent.getStringExtra("EXTRA_USERNAME");
+
+        //Set title bar text
+        getSupportActionBar().setTitle(extra_username);
+
+        TextView tvUserName = findViewById(R.id.tvUserName);
+        TextView tvFirstName = findViewById(R.id.tvFirstName);
+        TextView tvLastName = findViewById(R.id.tvLastName);
+        TextView tvRepos = findViewById(R.id.tvRepos);
+        TextView tvBio = findViewById(R.id.tvBio);
+
+        tvUserName.setText(extra_username);
+        tvFirstName.setText("");
+        tvLastName.setText("");
+        tvRepos.setText("");
+        tvBio.setText("");
+
     }
 }

--- a/app/src/main/java/com/example/githubusers/MainActivity.java
+++ b/app/src/main/java/com/example/githubusers/MainActivity.java
@@ -1,13 +1,66 @@
 package com.example.githubusers;
 
+import android.content.Intent;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
+import android.view.View;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.ListView;
+import android.widget.Toast;
 
 public class MainActivity extends AppCompatActivity {
+
+    String[] githubUsers ={
+            "@leo",
+            "@johngorithm",
+            "@codeplus254",
+            "@jb43daysGalore",
+            "@nateLEHI",
+            "@pendo_elizabeth",
+            "@trina",
+            "@tiffany",
+            "@sanchez",
+            "@eliza",
+            "@monalisa",
+            "@dilan"
+    };
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+
+        final ListView listView = (ListView) findViewById(R.id.lvUsers);
+
+        /**
+         * Assign adapter to ListView
+         * */
+        ArrayAdapter<String> adapter = new ArrayAdapter<String>(this,
+                android.R.layout.simple_list_item_1, githubUsers);
+        listView.setAdapter(adapter);
+
+        /**
+         * Assign listener to ListView
+         * */
+        listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+            @Override
+            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+
+                int itemPosition = position;
+                String userName = (String) listView.getItemAtPosition(position);
+
+                Toast.makeText(getApplicationContext(), "You clicked "+userName+" at position "+itemPosition+"", Toast.LENGTH_SHORT).show();
+                Intent intent = new Intent(getApplicationContext(), DetailActivity.class);
+                intent.putExtra("EXTRA_USERNAME", userName);
+                startActivity(intent);
+
+            }
+        });
+
+    }
+
+    public void launchUserDetails(View view){
+        //
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,6 +5,7 @@
     android:layout_height="match_parent">
 
     <TextView
+        android:id="@+id/tvUsersHeading"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="10dp"
@@ -15,10 +16,17 @@
         />
 
     <android.support.v7.widget.RecyclerView
-        android:id="@+id/users"
+        android:id="@+id/rvUsers"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:padding="10dp"
         android:layout_marginTop="25dp"/>
+
+    <ListView
+        android:id="@+id/lvUsers"
+        android:layout_below="@id/rvUsers"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" >
+    </ListView>
 
 </RelativeLayout>


### PR DESCRIPTION
#### What does this PR do?
- Opens list item details in another view

#### Description of Task to be completed?
> User installs app
> User sees a dummy list of Github users
> User is can navigate to detail activity of every entry via a click

#### How should this be manually tested?
* Clone this repo and 
`$ git clone -b ft-launch-detail-activity-from-main-activity-155820624 https://github.com/leonardnjura/github-users`
* Open cloned directory `github-users` in Android Studio
* Build with Gradle
* Run app in emulator device or actual connected device i.e. a physical Android phone or tablet

#### What are the relevant pivotal tracker stories?
[#155820624](https://www.pivotaltracker.com/story/show/155820624)

#### Screenshots
![screenshot 2019-03-04 at 15 45 43](https://user-images.githubusercontent.com/39657549/53734339-c56f5300-3e94-11e9-8de3-ba236f3bc67f.png)

![screenshot 2019-03-04 at 15 46 31](https://user-images.githubusercontent.com/39657549/53734340-c56f5300-3e94-11e9-8f77-fbea83bc3888.png)
